### PR TITLE
Initial proposal for Bluetooth Pairing addon

### DIFF
--- a/addons/bluetooth-pairing
+++ b/addons/bluetooth-pairing
@@ -1,0 +1,30 @@
+{
+  "id": "bluetoothpairing",
+  "name": "Bluetooth Pairing",
+  "description": "Pair with and connect to bluetooth devices",
+  "author": "CandleSmartHome.com",
+  "homepage_url": "https://github.com/flatsiedatsie/highlights",
+  "license_url": "https://raw.githubusercontent.com/flatsiedatsie/highlights/master/LICENSE",
+  "primary_type": "extension",
+  "packages": [
+    {
+      "architecture": "any",
+      "language": {
+        "name": "python",
+        "versions": [
+          "3.5",
+          "3.6",
+          "3.7",
+          "3.8"
+        ]
+      },
+      "version": "0.0.1",
+      "url": "https://github.com/flatsiedatsie/bluetoothpairing/releases/download/0.0.1/bluetoothpairing-0.0.1.tgz",
+      "checksum": "ab26ed6c16fc3f8b0195a976d4bfe08d789c3a1d1ac776b3fc60cb62e37b7440",
+      "gateway": {
+        "min": "0.10.0",
+        "max": "*"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This extension addon does three things:
- allows users to scan for bluetooth devices
- click on the pairing button of a found device to pair it.
- once paired, the connect toggle appears

It was designed to make it easy to connect bluetooth speakers, but that has proven impossible without installing something like BlueAlsa or PulseAudio. It has been tested with Bluealsa and a small change to the bluetooth service file, and then it was indeed possible to connect to a bluetooth speaker. Despite connecting ok, I didn't hear any sound though.

Although untested, it should in theory still be possible to connect to mice and keyboards, but this is untested.

It is currently not possible to do things like fill in passcodes.

As it could be useful to someone, and since the scanning functionality is already quite nice and the pairing works fine, I thought I'd release early.