### PR TITLE
Zigbee2MQTT version 0.4.0

### DIFF
--- a/addons/zigbee2mqtt-adapter.json
+++ b/addons/zigbee2mqtt-adapter.json
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "0.4.2",
-      "url": "https://github.com/kabbi/zigbee2mqtt-adapter/releases/download/0.4.2/zigbee2mqtt-adapter-0.4.2.tgz",
-      "checksum": "53b80c354edd71d8d4a8d312f6d0ccee316eec0f25a3b6dbda9d7199a004d049",
+      "version": "0.4.3",
+      "url": "https://github.com/kabbi/zigbee2mqtt-adapter/releases/download/0.4.3/zigbee2mqtt-adapter-0.4.3.tgz",
+      "checksum": "4c80f2025d5073154d7539e4fb9d16f34f18796aa0ddd03d8fab23245bbd26c1",
       "gateway": {
         "min": "0.10.0",
         "max": "*"

--- a/addons/zigbee2mqtt-adapter.json
+++ b/addons/zigbee2mqtt-adapter.json
@@ -1,6 +1,6 @@
 {
   "id": "zigbee2mqtt-adapter",
-  "name": "Zigbee2MQTT",
+  "name": "zigbee2mqtt-adapter",
   "description": "Zigbee device support. Can connect to devices that are supported by the Zigbee2MQTT project.",
   "author": "Kabbi",
   "homepage_url": "https://github.com/kabbi/zigbee2mqtt-adapter",

--- a/addons/zigbee2mqtt-adapter.json
+++ b/addons/zigbee2mqtt-adapter.json
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "0.4.3",
-      "url": "https://github.com/kabbi/zigbee2mqtt-adapter/releases/download/0.4.3/zigbee2mqtt-adapter-0.4.3.tgz",
-      "checksum": "4c80f2025d5073154d7539e4fb9d16f34f18796aa0ddd03d8fab23245bbd26c1",
+      "version": "0.4.4",
+      "url": "https://github.com/kabbi/zigbee2mqtt-adapter/releases/download/0.4.4/zigbee2mqtt-adapter-0.4.4.tgz",
+      "checksum": "4f2a8b74cffbf07f4ff20fe293147b319ea339407fadcaa94818eb3087db5400",
       "gateway": {
         "min": "0.10.0",
         "max": "*"

--- a/addons/zigbee2mqtt-adapter.json
+++ b/addons/zigbee2mqtt-adapter.json
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "0.3.3",
-      "url": "https://github.com/kabbi/zigbee2mqtt-adapter/releases/download/0.3.3/zigbee2mqtt-adapter-0.3.3.tgz",
-      "checksum": "27cee9260e83560a65a3d3ce0c8111a6efad0469983c6cdc8080b25f0d3d482f",
+      "version": "0.4.2",
+      "url": "https://github.com/kabbi/zigbee2mqtt-adapter/releases/download/0.4.2/zigbee2mqtt-adapter-0.4.2.tgz",
+      "checksum": "53b80c354edd71d8d4a8d312f6d0ccee316eec0f25a3b6dbda9d7199a004d049",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
Mayor release.

- More flexible exposes scanning
- Wider implementation of webthings capabilities
- Extracts more properties, including whether a device can be updated.
- Ability to create additional properties based on partial or sub-optimal data (variable scaling and translation, e.g. color from hex to CIE pair)
- More options as per user request, such as disabling the built-in Zigbee2MQTT instance.
- UI for updating devices
- UI can show a map of the network