### PR TITLE
Zigbee2MQTT 0.5.1

### DIFF
--- a/addons/zigbee2mqtt-adapter.json
+++ b/addons/zigbee2mqtt-adapter.json
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "0.5.0",
-      "url": "https://github.com/kabbi/zigbee2mqtt-adapter/releases/download/0.5.0/zigbee2mqtt-adapter-0.5.0.tgz",
-      "checksum": "55613d1deef28f1c9d4118c914f20032ad6155bf6c8c274b3652f8075cdc7af2",
+      "version": "0.5.1",
+      "url": "https://github.com/kabbi/zigbee2mqtt-adapter/releases/download/0.5.1/zigbee2mqtt-adapter-0.5.1.tgz",
+      "checksum": "d338520db8ccfdd0d0be5ae2b0ce6984dcbb97dcf90f85486ad7e85667cb8685",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
An attempt to address issue https://github.com/kabbi/zigbee2mqtt-adapter/issues/32

Out of curiosity: could this situation happen?
- user installs addon
- Addon gains new feature which can be toggled in the addon settings
- user looks at the addon settings, and sees the toggle is `disabled`, which is their preference. They do not click `apply`.
- The addon doesn't get the actual boolean for the new feature, but gets an 'undefined'.
- In this situation the addon has to make a choice, and assumes the preference is `enabled`, which is the intended default.
- The user's perception and the addon's perception are now out of sync.