### PR TITLE
psi-sg v1.2.0 - Add the hourly PM25 concentration

### DIFF
--- a/addons/psi-sg.json
+++ b/addons/psi-sg.json
@@ -16,8 +16,8 @@
         ]
       },
       "version": "1.1.2",
-      "url": "https://github.com/chas-iot/psi-sg/releases/download/v1.1.2/psi-sg-1.1.2.tgz",
-      "checksum": "e4907dfcfdb595eb28a20dd8a3d18751365d7503af440a0cb75ebed9aa5a54c2",
+      "url": "https://github.com/chas-iot/psi-sg/releases/download/v1.2.0/psi-sg-1.2.0.tgz",
+      "checksum": "06e697666aad7de54280edcd0c2bf5ac02d1820e1eeee3b39f7847f0dde52954",
       "gateway": {
         "min": "0.10.0",
         "max": "*"

--- a/addons/psi-sg.json
+++ b/addons/psi-sg.json
@@ -15,7 +15,7 @@
           "any"
         ]
       },
-      "version": "1.1.2",
+      "version": "1.2.0",
       "url": "https://github.com/chas-iot/psi-sg/releases/download/v1.2.0/psi-sg-1.2.0.tgz",
       "checksum": "06e697666aad7de54280edcd0c2bf5ac02d1820e1eeee3b39f7847f0dde52954",
       "gateway": {


### PR DESCRIPTION
The 2.5 micron Particulate Matter concentration (PM25), read hourly
in µg/m³ units, is a fast moving measurement of the most troublesome
pollutant in Singapore. The reading is interpreted with an additional
indicator.
This reading and indicator adds utility to the adapter, as the PSI is a
slow moving indicator averaged over 24 hours, so it often appears out of
line with reality.