### PR TITLE
Changed date-time-adapter to my fork - wfahle

### DIFF
--- a/addons/date-time-adapter.json
+++ b/addons/date-time-adapter.json
@@ -21,7 +21,7 @@
       },
       "version": "1.0.2",
       "url": "https://github.com/wfahle/date-time-adapter/releases/download/1.0.2/date-time-adapter-1.0.2.tgz",
-      "checksum": "71979a545571d07ee60ec658eeae5c2bd1c69897a0831b15fc870ed9b5ff45cfl",
+      "checksum": "71979a545571d07ee60ec658eeae5c2bd1c69897a0831b15fc870ed9b5ff45cf",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/date-time-adapter.json
+++ b/addons/date-time-adapter.json
@@ -3,8 +3,8 @@
   "name": "DateTime Adapter",
   "description": "A Date & Time adapter to create more advanced rules using sunrise, sunset, weekends, etc.",
   "author": "tomasy",
-  "homepage_url": "https://github.com/tomasy/date-time-adapter",
-  "license_url": "https://raw.githubusercontent.com/tomasy/date-time-adapter/master/LICENSE",
+  "homepage_url": "https://github.com/wfahle/date-time-adapter",
+  "license_url": "https://raw.githubusercontent.com/wfahle/date-time-adapter/master/LICENSE",
   "primary_type": "adapter",
   "packages": [
     {
@@ -19,9 +19,9 @@
           "3.9"
         ]
       },
-      "version": "1.0.1",
-      "url": "https://github.com/tomasy/date-time-adapter/releases/download/1.0.1/date-time-adapter-1.0.1.tgz",
-      "checksum": "281ec4b3d43ff5c08790e453b52dc0868e9525a15d4c48cc0c0320f3dfb1225f",
+      "version": "1.0.2",
+      "url": "https://github.com/wfahle/date-time-adapter/releases/download/1.0.2/date-time-adapter-1.0.2.tgz",
+      "checksum": "ccefe3e5589903d6a71e3c961e4a8bcca6d425d80571d96282b1fb6a9f346a1b",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/date-time-adapter.json
+++ b/addons/date-time-adapter.json
@@ -21,7 +21,7 @@
       },
       "version": "1.0.2",
       "url": "https://github.com/wfahle/date-time-adapter/releases/download/1.0.2/date-time-adapter-1.0.2.tgz",
-      "checksum": "ccefe3e5589903d6a71e3c961e4a8bcca6d425d80571d96282b1fb6a9f346a1b",
+      "checksum": "71979a545571d07ee60ec658eeae5c2bd1c69897a0831b15fc870ed9b5ff45cf",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/date-time-adapter.json
+++ b/addons/date-time-adapter.json
@@ -21,7 +21,7 @@
       },
       "version": "1.0.2",
       "url": "https://github.com/wfahle/date-time-adapter/releases/download/1.0.2/date-time-adapter-1.0.2.tgz",
-      "checksum": "71979a545571d07ee60ec658eeae5c2bd1c69897a0831b15fc870ed9b5ff45cf",
+      "checksum": "71979a545571d07ee60ec658eeae5c2bd1c69897a0831b15fc870ed9b5ff45cfl",
       "api": {
         "min": 2,
         "max": 2

--- a/addons/date-time-adapter.json
+++ b/addons/date-time-adapter.json
@@ -21,7 +21,7 @@
       },
       "version": "1.0.2",
       "url": "https://github.com/wfahle/date-time-adapter/releases/download/1.0.2/date-time-adapter-1.0.2.tgz",
-      "checksum": "71979a545571d07ee60ec658eeae5c2bd1c69897a0831b15fc870ed9b5ff45cf",
+      "checksum": "cfd7c6e3b4bdacc37985707eb75e18da0c6cd8f4abe8fa719009a9950410cd44",
       "api": {
         "min": 2,
         "max": 2


### PR DESCRIPTION
Hi there, I wanted the feature in issue 16, and a few others, so I took it upon myself to update the date-time-adapter with fixes to the way @damooooooooooh was doing things (he had a bug where if the desired offset was after the sunset, it would never happen because the sunset time would be reset at sunset to the next day). I also added properties to tell you how long in minutes until the next sunset/sunrise, and how long it’s been since the last one. I also added a couple of properties that let you see the sun’s azimuth and elevation, so that you can detect things like certain angles when the sun shines in a window, or position/uncover solar panels at certain times, etc. My repo is a fork from @damooooooooooh’s last changes at https://github.com/wfahle/date-time-adapter, and I am willing to take over maintenance. This is my PR to the addon-list.