### PR TITLE
Fixed path

### DIFF
--- a/addons/konnected-adapter.json
+++ b/addons/konnected-adapter.json
@@ -3,7 +3,7 @@
   "name": "Konnected.io Adapter",
   "description": "An adapter to configure and add konnected.io boards as things",
   "author": "wfahle",
-  "homepage_url": "https://github.com/WTIOaddons/konnected-adapter",
+  "homepage_url": "https://github.com/WTIOAddons/konnected-adapter",
   "license_url": "https://raw.githubusercontent.com/WTIOAddons/konnected-adapter/master/LICENSE",
   "primary_type": "adapter",
   "packages": [

--- a/addons/konnected-adapter.json
+++ b/addons/konnected-adapter.json
@@ -1,6 +1,6 @@
 {
   "id": "konnected-adapter",
-  "name": "Konnected.io Adapter",
+  "name": "Konnected Adapter",
   "description": "An adapter to configure and add konnected.io boards as things",
   "author": "wfahle",
   "homepage_url": "https://github.com/WTIOAddons/konnected-adapter",


### PR DESCRIPTION
This adapter allows you to configure and add Konnected.io boards to webthings without having to use amazon cloud or konnected.io cloud. Konnected.io are boards that allow you to update or piggy-back on existing wired alarm systems for integration to home automation. Currently they work with most platforms; this work adds WebThings.io as one of those platforms.