### PR TITLE
Add matrix-adapter 0.4.1

### DIFF
--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -15,6 +15,26 @@
           "any"
         ]
       },
+      "version": "0.4.1",
+      "url": "https://gateway.pinata.cloud/ipfs/QmZhvB7ASRAodbdMq5wRvL41aqZi2cuwer3mogGf7WYJmh/matrix-adapter-0.4.1.tgz",
+      "checksum": "371fc4954f88e4bbe5d75d98f31ac2a2a20800902437ecb545c80e779884159c",
+      "api": {
+        "min": 2,
+        "max": 2
+      },
+      "gateway": {
+        "min": "1.0.0",
+        "max": "*"
+      }
+    },
+    {
+      "architecture": "any",
+      "language": {
+        "name": "nodejs",
+        "versions": [
+          "any"
+        ]
+      },
       "version": "0.3.2",
       "url": "https://gateway.pinata.cloud/ipfs/QmbHhhsh5dYojjuC4Hz2MJyseAVS6ahmCgG7NUNpg6bieB/matrix-adapter-0.3.2.tgz",
       "checksum": "b546a62f12b06d941aff2f24a57cc89c83b8d2db189f515073d041ccc997e255",

--- a/addons/matrix-adapter.json
+++ b/addons/matrix-adapter.json
@@ -18,10 +18,6 @@
       "version": "0.4.1",
       "url": "https://gateway.pinata.cloud/ipfs/QmZhvB7ASRAodbdMq5wRvL41aqZi2cuwer3mogGf7WYJmh/matrix-adapter-0.4.1.tgz",
       "checksum": "371fc4954f88e4bbe5d75d98f31ac2a2a20800902437ecb545c80e779884159c",
-      "api": {
-        "min": 2,
-        "max": 2
-      },
       "gateway": {
         "min": "1.0.0",
         "max": "*"


### PR DESCRIPTION
* Changes to the new gateway 1.0.0 API, which has `.setTitle` and so on. So this no longer directly changes private properties of the Device and Outlet class.
* A small bugfix to predefined messages always getting posted in the default room.

https://gitlab.com/webthings/matrix-adapter/-/tags/v0.4.1

![Screenshot 2021-07-02 at 15-11-34 WebThings Gateway](https://user-images.githubusercontent.com/10872136/124299747-132c2100-db5e-11eb-9e3c-5e3b12eddac2.png)

For anyone interested, send issue reports and pull requests this way:
https://gitlab.com/webthings/matrix-adapter