### PR TITLE
irusb-adapter v1.0.1

### DIFF
--- a/addons/irusb-adapter.json
+++ b/addons/irusb-adapter.json
@@ -15,9 +15,9 @@
           "any"
         ]
       },
-      "version": "1.0.0",
-      "url": "https://github.com/freaktechnik/irusb-adapter/releases/download/v1.0.0/irusb-adapter-1.0.0.tgz",
-      "checksum": "22c817a338b7933fff8c5de3891379413f7b8966683af9e777296088e6783bc0",
+      "version": "1.0.1",
+      "url": "https://github.com/freaktechnik/irusb-adapter/releases/download/v1.0.1/irusb-adapter-1.0.1.tgz",
+      "checksum": "59dbf54fbbc3478f613c44e37cc7bf075224fe03dd2a737c6ae76a3c8c4964b9",
       "gateway": {
         "min": "0.10.0",
         "max": "*"


### PR DESCRIPTION
Primarily fixes actions not doing anything due to testing against upstream gateway instead of release.